### PR TITLE
Changes in docs for week 13

### DIFF
--- a/components/WorkstreamCard/index.tsx
+++ b/components/WorkstreamCard/index.tsx
@@ -58,7 +58,12 @@ const WorkstreamCard = ({
             {title}
           </Link>
         </Text>
-        <Text fontSize={15} color="rgba(201, 184, 255, 1)" fontStyle="italic">
+        <Text
+          fontSize={15}
+          color="rgba(201, 184, 255, 1)"
+          width={{ lg: "35rem" }}
+          fontStyle="italic"
+        >
           {discrpition}
         </Text>
         {objectives.length > 0 && (
@@ -148,45 +153,47 @@ const WorkstreamCard = ({
           gap={5}
           templateColumns="1fr"
         >
-          <GridItem textAlign="center" p={3} rounded="0.8rem" bg="#291555">
-            <Box w="full" h="full">
-              <Flex justify="space-between">
-                <Box>
-                  <Text w="full" textAlign="center">
-                    Total Contributors: {contributors}
-                  </Text>
-                  <Text
-                    fontWeight={400}
-                    fontFamily="inter"
-                    fontSize={"1.1rem"}
-                    color="rgba(255, 255, 255, 1)"
-                  >
-                    Stewards
-                  </Text>
-                  <Flex gap={1}>
-                    {stewards.length > 0 &&
-                      stewards.map((steward, index) => (
-                        <Link
-                          isExternal
-                          href={
-                            "https://gitcoin.co/" + steward.gitcoin_username
-                          }
-                          key={"steward-" + index}
-                        >
-                          <Image
-                            w="3rem"
-                            rounded="full"
-                            src={`/assets/stewards/webp/${steward.profile_image}`}
-                            alt={steward.name}
-                            key={index}
-                          />
-                        </Link>
-                      ))}
-                  </Flex>
-                </Box>
-              </Flex>
-            </Box>
-          </GridItem>
+          {stewards.length > 0 && (
+            <GridItem textAlign="center" p={3} rounded="0.8rem" bg="#291555">
+              <Box w="full" h="full">
+                <Flex justify="space-between">
+                  <Box>
+                    <Text w="full" textAlign="center">
+                      Total Contributors: {contributors}
+                    </Text>
+                    <Text
+                      fontWeight={400}
+                      fontFamily="inter"
+                      fontSize={"1.1rem"}
+                      color="rgba(255, 255, 255, 1)"
+                    >
+                      Stewards
+                    </Text>
+                    <Flex gap={1}>
+                      {stewards.length > 0 &&
+                        stewards.map((steward, index) => (
+                          <Link
+                            isExternal
+                            href={
+                              "https://gitcoin.co/" + steward.gitcoin_username
+                            }
+                            key={"steward-" + index}
+                          >
+                            <Image
+                              w="3rem"
+                              rounded="full"
+                              src={`/assets/stewards/webp/${steward.profile_image}`}
+                              alt={steward.name}
+                              key={index}
+                            />
+                          </Link>
+                        ))}
+                    </Flex>
+                  </Box>
+                </Flex>
+              </Box>
+            </GridItem>
+          )}
         </Grid>
         {/* <GridItem p={3} rounded="0.8rem" bg="#291555"></GridItem> */}
       </VStack>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -329,6 +329,7 @@ const Home: NextPage = () => {
         gap="2"
         textAlign="center"
         paddingTop="10"
+        paddingX="10"
       >
         <Text mb="2rem">
           The Stewards of Gitcoin DAO play a vital role in driving the Gitcoin

--- a/pages/workstreams.tsx
+++ b/pages/workstreams.tsx
@@ -47,7 +47,9 @@ const Workstream = ({ workstreamData }) => {
       flexDirection="column"
       gap="2"
       textAlign="center"
+      paddingX="10"
       paddingTop="10"
+      paddingBottom="10"
       width="full"
     >
       <Grid

--- a/pages/workstreams.tsx
+++ b/pages/workstreams.tsx
@@ -91,7 +91,7 @@ const Workstream = ({ workstreamData }) => {
                     ? workstream.stats.stable_coin_balance.rows[0].Stablecoins.toFixed(
                         2
                       )
-                    : "-"
+                    : "unavailable"
                 }
                 stewards={getStewards(workstream)}
               />


### PR DESCRIPTION
Remove contributors tab if no stewards are shown
Add margin around stewards and workstream pages for seperation with backgorund
Showing unavailable instead of "-" if not data available
width of boxes consistent for all screens
